### PR TITLE
works with xhtml anchors

### DIFF
--- a/inline.lua
+++ b/inline.lua
@@ -248,7 +248,8 @@ function dok.html2funcs(html, package)
    local canchor
    local lines = {}
    for line in html:gmatch('[^\n\r]+') do
-      local anchor = line:match('<a.-name="(.-)"/>')
+      local anchor = line:match('<a.-name=["\'](.-)["\']/>') 
+         or line:match('<a.-name=["\'](.-)["\']>.-</a>')
       local level, name = line:match('<h(%d)>(.*)</h%d>')
       if anchor then
          canchor = anchor


### PR DESCRIPTION
This makes the inline doc work with xhtml anchors : "<a name="nn.Linear"></a>".  Necessary for integration with readthedocs.org (ref. https://github.com/torch/torch7/issues/163) .