### PR TITLE
Fix for Lua 5.2

### DIFF
--- a/inline.lua
+++ b/inline.lua
@@ -40,6 +40,7 @@ local knownpkg = {}
 
 -- Lua 5.2 compatibility
 local unpack = unpack or table.unpack
+local loadstring = loadstring or load
 
 dok.inline = {}
 


### PR DESCRIPTION
In Lua 5.2, loadstring is deprecated in favor of load.